### PR TITLE
feat: add log handler to be able to use a custom logger

### DIFF
--- a/lib/configs.dart
+++ b/lib/configs.dart
@@ -1,15 +1,24 @@
-import 'package:meta/meta.dart';
 import 'package:dart_pusher_channels/api.dart';
+
+typedef LogHandler = void Function(Object? o);
 
 /// Package configurations.
 abstract class PusherChannelsPackageConfigs {
   static bool _logsEnabled = false;
+  static LogHandler _handler = print;
 
   /// Makes logs visible. If logs are enabled, you will able to see logs from different structures of the package.
   /// For example, event logs from [ConnectionDelegate]s.
   /// <br/>
-  /// Logs are done with [print] function and will be printed to the console that you app is running on.
-  static void enableLogs() {
+  /// Logs are done with [handler] if specified. Otherwise, they will be printed
+  /// to console using [print].
+  static void enableLogs({LogHandler? handler}) {
+    if (handler != null) {
+      _handler = handler;
+    } else {
+      _handler = print;
+    }
+
     _logsEnabled = true;
   }
 
@@ -20,19 +29,17 @@ abstract class PusherChannelsPackageConfigs {
 
   /// Use to check if logs are enabled.
   static bool get logsEnabled => _logsEnabled;
+
+  /// The handler log function.
+  static LogHandler get handler => _handler;
 }
 
 /// Logger that used across all the package.
 abstract class PusherChannelsPackageLogger {
   /// Wraps print by condition of [PusherChannelsPackageConfigs.logsEnabled]
   static void log(Object? object) {
-    if (PusherChannelsPackageConfigs.logsEnabled) print(object);
-  }
-
-  /// Mock for testing
-  @visibleForTesting
-  static void logTest(Object? object, [void Function(bool)? callBack]) {
-    callBack?.call(PusherChannelsPackageConfigs.logsEnabled);
-    log(object);
+    if (PusherChannelsPackageConfigs.logsEnabled) {
+      PusherChannelsPackageConfigs.handler(object);
+    }
   }
 }

--- a/lib/src/dart_pusher_channels_api.dart
+++ b/lib/src/dart_pusher_channels_api.dart
@@ -1,6 +1,5 @@
 /// Libraries for creating custom connection implementations
-export 'package:dart_pusher_channels/configs.dart'
-    show PusherChannelsPackageConfigs;
+export 'package:dart_pusher_channels/configs.dart';
 export 'package:dart_pusher_channels/src/channel/channel.dart'
     hide TokenAuthorizationDelegate, PusherTokenAuthDelegateException;
 export 'package:dart_pusher_channels/src/connection.dart';

--- a/lib/src/dart_pusher_channels_api.dart
+++ b/lib/src/dart_pusher_channels_api.dart
@@ -1,5 +1,6 @@
 /// Libraries for creating custom connection implementations
-
+export 'package:dart_pusher_channels/configs.dart'
+    show PusherChannelsPackageConfigs;
 export 'package:dart_pusher_channels/src/channel/channel.dart'
     hide TokenAuthorizationDelegate, PusherTokenAuthDelegateException;
 export 'package:dart_pusher_channels/src/connection.dart';
@@ -7,4 +8,3 @@ export 'package:dart_pusher_channels/src/event.dart';
 export 'package:dart_pusher_channels/src/event_names.dart';
 export 'package:dart_pusher_channels/src/options.dart';
 export 'package:dart_pusher_channels/src/pusher_client.dart';
-export 'package:dart_pusher_channels/configs.dart';

--- a/test/dart_pusher_channels_test.dart
+++ b/test/dart_pusher_channels_test.dart
@@ -1,13 +1,42 @@
 import 'package:dart_pusher_channels/configs.dart';
 import 'package:test/test.dart';
 
+import 'utils/log_grabber.dart';
+
 void main() {
-  test('Test enabling/disabling logs', () {
-    PusherChannelsPackageConfigs.enableLogs();
-    PusherChannelsPackageLogger.logTest(
-        'hello', (isEnabled) => expect(isEnabled, true));
-    PusherChannelsPackageConfigs.disableLogs();
-    PusherChannelsPackageLogger.logTest(
-        'hello', (isEnabled) => expect(isEnabled, false));
+  group('logs', () {
+    test('should enable and disable logs', () {
+      grabLogs((printedLogs) {
+        PusherChannelsPackageConfigs.enableLogs();
+        PusherChannelsPackageLogger.log('hello');
+        expect(printedLogs.length, 1);
+        expect(printedLogs[0], 'hello');
+
+        PusherChannelsPackageConfigs.disableLogs();
+        PusherChannelsPackageLogger.log('bye');
+        expect(printedLogs.length, 1);
+      });
+    });
+
+    test('should use a custom log handler', () {
+      grabLogs((printedLogs) {
+        final handledLines = <String>[];
+
+        PusherChannelsPackageConfigs.enableLogs(
+          handler: (o) => handledLines.add(o.toString()),
+        );
+        PusherChannelsPackageLogger.log('hello');
+        PusherChannelsPackageLogger.log('123');
+
+        expect(handledLines, ['hello', '123']);
+        expect(printedLogs, isEmpty);
+
+        PusherChannelsPackageConfigs.enableLogs();
+        PusherChannelsPackageLogger.log('hello');
+        expect(handledLines.length, 2);
+        expect(printedLogs.length, 1);
+        expect(printedLogs[0], 'hello');
+      });
+    });
   });
 }

--- a/test/utils/log_grabber.dart
+++ b/test/utils/log_grabber.dart
@@ -1,0 +1,13 @@
+import 'dart:async';
+
+/// Util function that grabs all printed logs made on
+/// [print]
+T grabLogs<T>(T Function(List<String> printedLogs) callback) {
+  final printedLogs = <String>[];
+  return runZoned(
+    () => callback(printedLogs),
+    zoneSpecification: ZoneSpecification(print: (s, p, z, line) {
+      printedLogs.add(line);
+    }),
+  );
+}


### PR DESCRIPTION
* Add custom logger handler to use a custom Logger instead of printing to console.
* Hide `PusherChannelsPackageLogger` from public API.
* Fix logger tests not capturing what was being printed to console.
* Remove `logTest` method as it is not needed anymore.
