### PR TITLE
fix: only attempt to subscribe/unsubscribe to channels when socket id is set

### DIFF
--- a/lib/src/channel/channel.dart
+++ b/lib/src/channel/channel.dart
@@ -57,7 +57,7 @@ class PrivateChannel extends Channel {
   final void Function(PusherAuthenticationException error)? onAuthFailed;
 
   /// [PrivateChannel] subscription is established only if
-  /// [connectionDelegate.socketId] is set and
+  /// [connectionDelegate.socketId] is set (if connection is established) and
   /// [authorizationDelegate.authenticationString] succeeds
   /// with valid auth code.
   @override
@@ -82,6 +82,8 @@ class PrivateChannel extends Channel {
     } catch (ex) {}
   }
 
+  /// [PrivateChannel] unsubscription is established only if
+  /// [connectionDelegate.socketId] is set (if connection is established)
   @override
   void unsubscribe() {
     if (connectionDelegate.socketId == null) {
@@ -101,6 +103,8 @@ class PublicChannel extends Channel {
       {required String name, required ConnectionDelegate connectionDelegate})
       : super(name: name, connectionDelegate: connectionDelegate);
 
+  /// [PublicChannel] subscription is established only if
+  /// [connectionDelegate.socketId] is set (if connection is established)
   @override
   void subscribe() {
     if (connectionDelegate.socketId == null) {
@@ -113,6 +117,8 @@ class PublicChannel extends Channel {
         channelName: null));
   }
 
+  /// [PublicChannel] unsubscription is established only if
+  /// [connectionDelegate.socketId] is set (if connection is established)
   @override
   void unsubscribe() {
     if (connectionDelegate.socketId == null) {

--- a/lib/src/channel/channel.dart
+++ b/lib/src/channel/channel.dart
@@ -57,7 +57,7 @@ class PrivateChannel extends Channel {
   final void Function(PusherAuthenticationException error)? onAuthFailed;
 
   /// [PrivateChannel] subscription is established only if
-  /// [ConnectionDelegate.socketId] is set and
+  /// [connectionDelegate.socketId] is set and
   /// [authorizationDelegate.authenticationString] succeeds
   /// with valid auth code.
   @override

--- a/lib/src/channel/channel.dart
+++ b/lib/src/channel/channel.dart
@@ -84,6 +84,10 @@ class PrivateChannel extends Channel {
 
   @override
   void unsubscribe() {
+    if (connectionDelegate.socketId == null) {
+      return;
+    }
+
     connectionDelegate.send(SendEvent(
         data: {'channel': name},
         name: PusherEventNames.unsubscribe,
@@ -99,6 +103,10 @@ class PublicChannel extends Channel {
 
   @override
   void subscribe() {
+    if (connectionDelegate.socketId == null) {
+      return;
+    }
+
     connectionDelegate.send(SendEvent(
         data: {'channel': name},
         name: PusherEventNames.subscribe,
@@ -107,6 +115,10 @@ class PublicChannel extends Channel {
 
   @override
   void unsubscribe() {
+    if (connectionDelegate.socketId == null) {
+      return;
+    }
+
     connectionDelegate.send(SendEvent(
         data: {'channel': name},
         name: PusherEventNames.unsubscribe,


### PR DESCRIPTION
* Only attempt to subscribe to a private channel if socket id is set, as it is necessary for authenticating a private channel on the server side.