### PR TITLE
fix: pusher disconnection not being registered in some cases

### DIFF
--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -38,10 +38,13 @@ abstract class ConnectionDelegate {
 
   ConnectionDelegate({required this.options});
 
+  final Duration _pingDurationBeforeDisconnect = const Duration(seconds: 30);
+
   String? _socketId;
   bool _pongRecieved = false;
   bool _isDisconnectedManually = false;
   Timer? _timer;
+  Timer? _pingTimer;
 
   /// Socket id sent from the server after connection is established
   String? get socketId => _socketId;
@@ -96,6 +99,7 @@ abstract class ConnectionDelegate {
   @protected
   void ping() {
     PusherChannelsPackageLogger.log('pinging');
+    setPingTimer();
   }
 
   /// Send events
@@ -156,6 +160,7 @@ abstract class ConnectionDelegate {
             data: data,
             name: name,
             onEventRecieved: (_, __, ___) {});
+        cancelPingTimer();
         return event;
       default:
         return null;
@@ -258,4 +263,19 @@ abstract class ConnectionDelegate {
 
   @protected
   bool isDisposed = false;
+
+  @mustCallSuper
+  @protected
+  void setPingTimer() {
+    _pingTimer = Timer(_pingDurationBeforeDisconnect, disconnect);
+  }
+
+  /// Cancelling a timer
+  @mustCallSuper
+  @protected
+  void cancelPingTimer() {
+    PusherChannelsPackageLogger.log('PingTimer is canceled');
+    _pingTimer?.cancel();
+    _pingTimer = null;
+  }
 }

--- a/lib/src/web_socket_connection.dart
+++ b/lib/src/web_socket_connection.dart
@@ -1,9 +1,10 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:dart_pusher_channels/configs.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
-import 'dart:async';
+
 import 'connection.dart';
 import 'event.dart';
 import 'event_names.dart';
@@ -67,11 +68,20 @@ class WebSocketChannelConnectionDelegate extends ConnectionDelegate {
   Future<void> connect() async {
     await super.connect();
     _connectionCompleter = Completer();
-    runZonedGuarded(() {
-      _socketChannel = WebSocketChannel.connect(options.uri);
-      _socketChannel?.stream.listen(onEventRecieved,
-          cancelOnError: true, onError: _onConnectionError);
-    }, _onConnectionError);
+    runZonedGuarded(
+      () {
+        _socketChannel = WebSocketChannel.connect(options.uri);
+        _socketChannel?.stream.listen(
+          onEventRecieved,
+          cancelOnError: true,
+          onError: _onConnectionError,
+          onDone: () {
+            disconnect();
+          },
+        );
+      },
+      _onConnectionError,
+    );
     return _connectionCompleter.future;
   }
 


### PR DESCRIPTION
* Add a pong timeout after a ping as present in [Pusher Channel official docs](https://pusher.com/docs/channels/using_channels/connection/#pongtimeout-1425322078). Timeout value is set as official Pusher libraries, such as the [JS client library](https://github.com/pusher/pusher-js#pongtimeout-integer).
* Add `onDone` callback to listen for disconnections on the server side or network changes.

These changes have been tested on real devices (Android and iOS) and it was determined that they were necessary because disconnections may pass unnoticed by this library, especially in iOS after sending the app to background or locking the device, both cases where the OS closes the socket.