### PR TITLE
Fix connections leak

### DIFF
--- a/lib/src/pusher_client.dart
+++ b/lib/src/pusher_client.dart
@@ -92,8 +92,7 @@ class PusherChannelsClient {
         onConnectionErrorHandle?.call(error, trace, () async {
           (_delegate as WebSocketChannelConnectionDelegate).resetTries();
           try {
-            await _delegate.disconnect();
-            await connect();
+            await reconnect();
             resubscribeToChannels();
             // ignore: empty_catches
           } catch (e) {}
@@ -117,8 +116,8 @@ class PusherChannelsClient {
   Future<void> close() => _delegate.dispose();
 
   /// Disconnecting with current [ConnectionDelegate]
-  Future<void> disconnect() => _delegate.disconnect();
+  Future<void> disconnect() => _delegate.disconnectSafely();
 
   /// Reconnecting with current [ConnectionDelegate]
-  void reconnect() => _delegate.reconnect();
+  Future<void> reconnect() => _delegate.reconnect();
 }

--- a/lib/src/pusher_client.dart
+++ b/lib/src/pusher_client.dart
@@ -114,7 +114,7 @@ class PusherChannelsClient {
   }
 
   /// Connect with current [ConnectionDelegate]
-  Future<void> connect() => _delegate.connect();
+  Future<void> connect() => _delegate.connectSafely();
 
   /// Permanently close this instance
   Future<void> close() => _delegate.dispose();

--- a/lib/src/pusher_client.dart
+++ b/lib/src/pusher_client.dart
@@ -14,7 +14,6 @@ class PusherChannelsClient {
 
   /// If [PusherEventNames.pong] was recieved then this duration is set to timer
   /// while waiting for pong next time
-  final Duration pingWaitPongDuration;
 
   /// Events recieved by client's [ConnectionDelegate] and mapped
   /// as [PusherReadEvent]
@@ -73,18 +72,16 @@ class PusherChannelsClient {
     return _channelEventFactory(name, channelName, data);
   }
 
-  PusherChannelsClient(
-      {required this.options,
-      required ConnectionDelegate delegate,
-      this.pingWaitPongDuration =
-          PusherChannelsPackageConfigs.defaultPingWaitPongDuration})
-      : _delegate = delegate;
+  PusherChannelsClient({
+    required this.options,
+    required ConnectionDelegate delegate,
+  }) : _delegate = delegate;
 
   /// Build a client over the Web socket connection
   PusherChannelsClient.websocket(
       {required this.options,
       int reconnectTries = 4,
-      this.pingWaitPongDuration =
+      Duration pingWaitPongDuration =
           PusherChannelsPackageConfigs.defaultPingWaitPongDuration,
       void Function(dynamic error, StackTrace? trace, void Function() refresh)?
           onConnectionErrorHandle}) {


### PR DESCRIPTION
I summed up all the fixes about connection leaking in this PR. Please, check the commits @nicobritos. 

About the thing that the connection is killed in background - yes, it happens but it's possible to handle it by the package (onConnectionErrorHandler) for example. Moreover, timer (checking for pong) is resumed in foreground - so the package tries too keep connection with all possible methods.

All that we need is to document those use-cases for flutter. Maybe I will create separate .md file.